### PR TITLE
Update alpine base image to 3.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.3
+FROM alpine:3.19.1
 LABEL maintainer="Fedor Borshev <fedor@borshev.com>"
 
 RUN apk update \


### PR DESCRIPTION
Updates the Alpine version to `3.19.1`, with support for newer versions of `postgres-client`.
The currently available version `16.2` is compatible with PostgreSQL versions spanning from 9.2 to 16.2.